### PR TITLE
Add initial support for optional IAP access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+# Makefile argument to enable IAP
+#
+# $ make terraform/apply IAP_ENABLED=true
+#
+# https://cloud.google.com/iap/docs/tutorial-gce
+IAP_ENABLED := true
+
 .PHONY: help
 help: ## Print this help menu
 help:
@@ -8,6 +15,10 @@ help:
 	@echo "* GOOGLE_APPLICATION_CREDENTIALS (${GOOGLE_APPLICATION_CREDENTIALS})"
 	@echo "* VAULT_PUBLIC_DOMAIN (${VAULT_PUBLIC_DOMAIN})"
 	@echo
+	@echo Google Cloud IAP OAuth2 environment variables:
+	@echo "* GOOGLE_CLIENT_ID (${GOOGLE_CLIENT_ID})"
+	@echo "* GOOGLE_CLIENT_SECRET (${GOOGLE_CLIENT_SECRET})"
+	@echo
 	@echo 'Usage: make <target>'
 	@echo
 	@echo 'Targets:'
@@ -15,53 +26,62 @@ help:
 
 .PHONY: packer/validate
 packer/validate: ## Validates the Packer config
-	cd packer && packer validate template.json
+	@cd packer && packer validate template.json
 
 .PHONY: packer/build
 packer/build: ## Forces a build with Packer
-	cd packer && time packer build \
+	@cd packer && time packer build \
 		-force \
 		-timestamp-ui \
 		template.json
 
 .PHONY: terraform/console
 terraform/console: ## Starts the Terraform console
-	terraform console
+	@terraform console
 
 .PHONY: terraform/validate
 terraform/validate: ## Validates the Terraform config
-	terraform validate
+	@terraform validate
 
 .PHONY: terraform/plan
 terraform/plan: ## Runs the Terraform plan command
-	terraform plan \
+	@terraform plan \
 		-var="project=${GOOGLE_PROJECT}" \
 		-var="dns_enabled=true" \
 		-var="bucket_force_destroy=false" \
 		-var="dns_managed_zone_dns_name=${VAULT_PUBLIC_DOMAIN}" \
 		-var="dns_record_set_name_prefix=public" \
+		-var="iap_enabled=${IAP_ENABLED}" \
+		-var="iap_client_id=${GOOGLE_CLIENT_ID}" \
+		-var="iap_client_secret=${GOOGLE_CLIENT_SECRET}" \
 		-var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
 
 .PHONY: terraform/apply
 terraform/apply: ## Runs and auto-apporves the Terraform apply command
-	terraform apply \
+	@terraform apply \
 		-auto-approve \
 		-var="project=${GOOGLE_PROJECT}" \
 		-var="dns_enabled=true" \
 		-var="bucket_force_destroy=false" \
 		-var="dns_managed_zone_dns_name=${VAULT_PUBLIC_DOMAIN}" \
 		-var="dns_record_set_name_prefix=public" \
+		-var="iap_enabled=${IAP_ENABLED}" \
+		-var="iap_client_id=${GOOGLE_CLIENT_ID}" \
+		-var="iap_client_secret=${GOOGLE_CLIENT_SECRET}" \
 		-var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
 
 .PHONY: terraform/destroy
 terraform/destroy: ## Runs and auto-apporves the Terraform destroy command
-	terraform destroy \
+	@terraform destroy \
 		-auto-approve \
 		-var="project=${GOOGLE_PROJECT}" \
 		-var="dns_enabled=true" \
 		-var="bucket_force_destroy=false" \
 		-var="dns_managed_zone_dns_name=${VAULT_PUBLIC_DOMAIN}" \
 		-var="dns_record_set_name_prefix=public" \
+		-var="iap_enabled=${IAP_ENABLED}" \
+		-var="iap_client_id=${GOOGLE_CLIENT_ID}" \
+		-var="iap_client_secret=${GOOGLE_CLIENT_SECRET}" \
 		-var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
 
 .PHONY: mtls/init/macos/keychain

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@
 #
 # https://cloud.google.com/iap/docs/tutorial-gce
 IAP_ENABLED := true
+#
+# $ make terraform/apply IAP_ENABLED=true IAP_MEMBER_EMAILS="$EMAIL_1@gmail.com,$EMAIL_2@gmail.com"
+#
+IAP_MEMBER_EMAILS := ""
 
 .PHONY: help
 help: ## Print this help menu
@@ -17,7 +21,7 @@ help:
 	@echo
 	@echo Google Cloud IAP OAuth2 environment variables:
 	@echo "* GOOGLE_CLIENT_ID (${GOOGLE_CLIENT_ID})"
-	@echo "* GOOGLE_CLIENT_SECRET (${GOOGLE_CLIENT_SECRET})"
+	@echo "* GOOGLE_CLIENT_SECRET (<sensitive>)"
 	@echo
 	@echo 'Usage: make <target>'
 	@echo
@@ -52,6 +56,7 @@ terraform/plan: ## Runs the Terraform plan command
 		-var="dns_managed_zone_dns_name=${VAULT_PUBLIC_DOMAIN}" \
 		-var="dns_record_set_name_prefix=public" \
 		-var="iap_enabled=${IAP_ENABLED}" \
+		-var="iap_member_emails=${IAP_MEMBER_EMAILS}" \
 		-var="iap_client_id=${GOOGLE_CLIENT_ID}" \
 		-var="iap_client_secret=${GOOGLE_CLIENT_SECRET}" \
 		-var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
@@ -66,6 +71,7 @@ terraform/apply: ## Runs and auto-apporves the Terraform apply command
 		-var="dns_managed_zone_dns_name=${VAULT_PUBLIC_DOMAIN}" \
 		-var="dns_record_set_name_prefix=public" \
 		-var="iap_enabled=${IAP_ENABLED}" \
+		-var="iap_member_emails=${IAP_MEMBER_EMAILS}" \
 		-var="iap_client_id=${GOOGLE_CLIENT_ID}" \
 		-var="iap_client_secret=${GOOGLE_CLIENT_SECRET}" \
 		-var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
@@ -80,6 +86,7 @@ terraform/destroy: ## Runs and auto-apporves the Terraform destroy command
 		-var="dns_managed_zone_dns_name=${VAULT_PUBLIC_DOMAIN}" \
 		-var="dns_record_set_name_prefix=public" \
 		-var="iap_enabled=${IAP_ENABLED}" \
+		-var="iap_member_emails=${IAP_MEMBER_EMAILS}" \
 		-var="iap_client_id=${GOOGLE_CLIENT_ID}" \
 		-var="iap_client_secret=${GOOGLE_CLIENT_SECRET}" \
 		-var="credentials=${GOOGLE_APPLICATION_CREDENTIALS}"

--- a/dns.tf
+++ b/dns.tf
@@ -14,3 +14,14 @@ resource "google_dns_managed_zone" "vault" {
   name     = "vault"
   dns_name = format("%s.", var.dns_managed_zone_dns_name)
 }
+
+resource "google_dns_record_set" "iap" {
+  count = (var.dns_enabled && var.iap_enabled) ? 1 : 0
+  name  = format("%s.%s.", "iap", var.dns_managed_zone_dns_name)
+  type  = "A"
+  ttl   = 300
+
+  managed_zone = google_dns_managed_zone.vault.0.name
+
+  rrdatas = [google_compute_global_address.vault_iap_external.0.address]
+}

--- a/instance_group_manager.tf
+++ b/instance_group_manager.tf
@@ -13,6 +13,11 @@ resource "google_compute_region_instance_group_manager" "vault" {
     port = 8200
   }
 
+  named_port {
+    name = "vault-http-iap"
+    port = 8202
+  }
+
   version {
     instance_template = google_compute_instance_template.vault.self_link
   }

--- a/network_external_iap_lb.tf
+++ b/network_external_iap_lb.tf
@@ -1,0 +1,66 @@
+resource "google_compute_global_address" "vault_iap_external" {
+  count = (var.iap_enabled && var.dns_enabled) ? 1 : 0
+  name  = "vault-iap-external"
+}
+
+resource "google_compute_global_forwarding_rule" "vault_iap_external" {
+  count                 = (var.iap_enabled && var.dns_enabled) ? 1 : 0
+  name                  = "vault-iap-external"
+  ip_protocol           = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  target                = google_compute_target_https_proxy.vault_iap.0.id
+  ip_address            = google_compute_global_address.vault_iap_external.0.address
+  port_range            = "443"
+}
+
+resource "google_compute_target_https_proxy" "vault_iap" {
+  count            = (var.iap_enabled && var.dns_enabled) ? 1 : 0
+  name             = "vault-iap-proxy"
+  url_map          = google_compute_url_map.vault_iap.0.id
+  ssl_certificates = [google_compute_ssl_certificate.vault_iap.0.id]
+}
+
+resource "google_compute_ssl_certificate" "vault_iap" {
+  count       = (var.iap_enabled && var.dns_enabled) ? 1 : 0
+  name        = "vault-iap-certificate"
+  private_key = tls_private_key.vault-server.private_key_pem
+  certificate = tls_locally_signed_cert.vault-server.cert_pem
+}
+
+resource "google_compute_url_map" "vault_iap" {
+  count           = (var.iap_enabled && var.dns_enabled) ? 1 : 0
+  name            = "vault-iap-url-map"
+  default_service = google_compute_backend_service.vault_iap.0.id
+}
+
+resource "google_compute_backend_service" "vault_iap" {
+  count                 = (var.iap_enabled && var.dns_enabled) ? 1 : 0
+  name                  = "vault-iap-backend-service"
+  load_balancing_scheme = "EXTERNAL"
+  session_affinity      = "CLIENT_IP"
+  protocol              = "HTTPS"
+  port_name             = "vault-http-iap"
+  health_checks         = [google_compute_health_check.vault_iap.0.self_link]
+
+  backend {
+    group = google_compute_region_instance_group_manager.vault.instance_group
+  }
+
+  iap {
+      oauth2_client_id     = var.iap_client_id
+      oauth2_client_secret = var.iap_client_secret
+  }
+}
+
+resource "google_compute_health_check" "vault_iap" {
+  count               = (var.iap_enabled && var.dns_enabled) ? 1 : 0
+  name                = "vault-iap-backend-service-health-check"
+  timeout_sec         = 1
+  check_interval_sec  = 1
+  healthy_threshold   = 2
+  unhealthy_threshold = 5
+
+  ssl_health_check {
+    port = 8202
+  }
+}

--- a/network_external_lb.tf
+++ b/network_external_lb.tf
@@ -26,7 +26,12 @@ resource "google_compute_backend_service" "vault" {
   health_checks         = [google_compute_health_check.vault.self_link]
 
   backend {
-    max_connections_per_instance = 10000
+    // This value used to be set, but backend services that share the same
+    // target instance group must have the same value. The optional IAP
+    // functionality uses HTTPS, which doesn't seem to support this value?
+    //
+    // max_connections_per_instance = 10000
+
     group = google_compute_region_instance_group_manager.vault.instance_group
   }
 }

--- a/network_firewall.tf
+++ b/network_firewall.tf
@@ -26,3 +26,19 @@ resource "google_compute_firewall" "allow_vault" {
     ports    = [8200]
   }
 }
+
+resource "google_compute_firewall" "allow_vault_iap" {
+  count         = var.iap_enabled ? 1 : 0
+  name          = "allow-vault-iap"
+  network       = google_compute_network.vault.name
+
+  source_ranges = [
+    "130.211.0.0/22",
+    "35.191.0.0/16"
+  ]
+
+  allow {
+    protocol = "tcp"
+    ports    = [8202]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,5 +28,15 @@ output "load_balancer_ip" {
 
 output "dns_name_servers" {
   description = "Delegate your managed_zone to these virtual name servers if DNS is enabled"
-  value       = var.dns_enabled ? google_dns_managed_zone.vault[0].name_servers : []
+  value       = var.dns_enabled ? google_dns_managed_zone.vault.0.name_servers : []
+}
+
+output "dns_url" {
+  description = "The mTLS enabled public URL using the configured DNS name"
+  value       = (var.dns_enabled) ? format("https://%s", trimsuffix(google_dns_record_set.public.0.name, ".")) : ""
+}
+
+output "iap_url" {
+  description = "The TLS enabled public URL using Google Cloud IAP as the first layer of authentication"
+  value       = (var.iap_enabled && var.dns_enabled) ? format("https://%s", trimsuffix(google_dns_record_set.iap.0.name, ".")) : ""
 }

--- a/packer/configs/vault/agent.hcl
+++ b/packer/configs/vault/agent.hcl
@@ -32,3 +32,10 @@ listener "tcp" {
   tls_disable_client_certs           = false
   tls_require_and_verify_client_cert = true
 }
+
+// Listener for IAP only
+listener "tcp" {
+  address                            = "{PRIVATE-IPV4}:8202"
+  tls_cert_file                      = "/vault/config/server.pem"
+  tls_key_file                       = "/vault/config/server-key.pem"
+}

--- a/tls_cert_server.tf
+++ b/tls_cert_server.tf
@@ -7,15 +7,27 @@ resource "tls_cert_request" "vault-server" {
   key_algorithm   = tls_private_key.vault-server.algorithm
   private_key_pem = tls_private_key.vault-server.private_key_pem
 
-  ip_addresses = [
+  ip_addresses = var.iap_enabled ? [
+    google_compute_global_address.vault_external.address,
+    google_compute_global_address.vault_iap_external.0.address,
+    "127.0.0.1",
+  ] : [
     google_compute_global_address.vault_external.address,
     "127.0.0.1",
   ]
 
+  // NOTE: on iOS it seems that the certificate DNS extension order might matter? maybe alphabetically?
+  //       ... or maybe the mTLS support is broken? Need to investigate that nonsense later.
+  //
+  //       * https://support.apple.com/en-us/HT210176
+  //       * https://support.apple.com/guide/deployment-reference-ios/certificate-deployment-apd1145c7251/1/web/1.0
+  //
+  // TODO: eventually I need to cleanup these DNS names, but it works.
   dns_names = var.dns_enabled ? [
     "localhost",
     "server.global.vault",
     trimsuffix(google_dns_record_set.public.0.name, "."),
+    var.iap_enabled ? trimsuffix(google_dns_record_set.iap.0.name, ".") : "localhost",
   ] : [
     "localhost",
     "server.global.vault",

--- a/vars.tf
+++ b/vars.tf
@@ -110,3 +110,20 @@ variable "tls_validity_period_hours" {
   default = 17520
   description = "The total number of hours the generated mTLS certificates are valid for with a default of 2 years"
 }
+
+// TODO: consider enabling support for IAP without forcing DNS
+variable "iap_enabled" {
+  type    = string
+  default = ""
+  description = "Enable GCP Identity-Aware Proxy public endpoint access (requires DNS to also be enabled)"
+}
+
+variable "iap_client_id" {
+  type    = string
+  default = "GCP OAuth2 client ID"
+}
+
+variable "iap_client_secret" {
+  type    = string
+  default = "GCP OAuth2 client secret"
+}

--- a/vars.tf
+++ b/vars.tf
@@ -127,3 +127,8 @@ variable "iap_client_secret" {
   type    = string
   default = "GCP OAuth2 client secret"
 }
+
+variable "iap_member_emails" {
+  type    = string
+  default = "IAP member emails"
+}


### PR DESCRIPTION
This PR introduces support for optional [IAP](https://cloud.google.com/iap/docs) access. This will require enabling a new API to the GCP project before it can be used.

```console
$ gcloud services enable iam.googleapis.com
...
```

```console
$ make terraform/apply IAP_ENABLED=true IAP_MEMBER_EMAILS="$YOUR_EMAIL_1@gmail.com,$YOUR_EMAIL_2@gmail.com"
...
```