### PR TITLE
Add initial Cloud Armor configuration option with google-beta provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ IAP_ENABLED := true
 # $ make terraform/apply IAP_ENABLED=true IAP_MEMBER_EMAILS="$EMAIL_1@gmail.com,$EMAIL_2@gmail.com"
 #
 IAP_MEMBER_EMAILS := ""
+#
+#
+# Makefile argument to enable Cloud Armor (only for IAP endpoint currently)
+CLOUD_ARMOR_ENABLED := false
 
 .PHONY: help
 help: ## Print this help menu
@@ -55,6 +59,7 @@ terraform/plan: ## Runs the Terraform plan command
 		-var="bucket_force_destroy=false" \
 		-var="dns_managed_zone_dns_name=${VAULT_PUBLIC_DOMAIN}" \
 		-var="dns_record_set_name_prefix=public" \
+		-var="cloud_armor_enabled=${CLOUD_ARMOR_ENABLED}" \
 		-var="iap_enabled=${IAP_ENABLED}" \
 		-var="iap_member_emails=${IAP_MEMBER_EMAILS}" \
 		-var="iap_client_id=${GOOGLE_CLIENT_ID}" \
@@ -70,6 +75,7 @@ terraform/apply: ## Runs and auto-apporves the Terraform apply command
 		-var="bucket_force_destroy=false" \
 		-var="dns_managed_zone_dns_name=${VAULT_PUBLIC_DOMAIN}" \
 		-var="dns_record_set_name_prefix=public" \
+		-var="cloud_armor_enabled=${CLOUD_ARMOR_ENABLED}" \
 		-var="iap_enabled=${IAP_ENABLED}" \
 		-var="iap_member_emails=${IAP_MEMBER_EMAILS}" \
 		-var="iap_client_id=${GOOGLE_CLIENT_ID}" \
@@ -85,6 +91,7 @@ terraform/destroy: ## Runs and auto-apporves the Terraform destroy command
 		-var="bucket_force_destroy=false" \
 		-var="dns_managed_zone_dns_name=${VAULT_PUBLIC_DOMAIN}" \
 		-var="dns_record_set_name_prefix=public" \
+		-var="cloud_armor_enabled=${CLOUD_ARMOR_ENABLED}" \
 		-var="iap_enabled=${IAP_ENABLED}" \
 		-var="iap_member_emails=${IAP_MEMBER_EMAILS}" \
 		-var="iap_client_id=${GOOGLE_CLIENT_ID}" \

--- a/cloud_armor.tf
+++ b/cloud_armor.tf
@@ -1,0 +1,55 @@
+resource "google_compute_security_policy" "vault" {
+  count = var.cloud_armor_enabled ? 1 : 0
+
+  provider = google-beta
+
+  name  = "vault-cloud-armor"
+
+  rule {
+        action   = "deny(403)"
+        priority = "1000"
+        match {
+            expr {
+                expression = "evaluatePreconfiguredExpr('xss-stable')"
+            }
+        }
+  }
+
+  rule {
+        action   = "deny(403)"
+        priority = "1001"
+        match {
+            expr {
+                expression = "evaluatePreconfiguredExpr('scannerdetection-stable')"
+            }
+        }
+  }
+
+  rule {
+        action   = "deny(403)"
+        priority = "1002"
+        match {
+            expr {
+                expression = "evaluatePreconfiguredExpr('protocolattack-stable')"
+            }
+        }
+  }
+
+  rule {
+        action   = "allow"
+        priority = "2147483647"
+        match {
+            versioned_expr = "SRC_IPS_V1"
+            config {
+                src_ip_ranges = ["*"]
+            }
+        }
+        description = "default rule"
+  }
+
+  adaptive_protection_config {
+      layer_7_ddos_defense_config {
+        enable = var.cloud_armor_enabled
+      }
+  }
+}

--- a/network_external_iap_lb.tf
+++ b/network_external_iap_lb.tf
@@ -42,6 +42,8 @@ resource "google_compute_backend_service" "vault_iap" {
   port_name             = "vault-http-iap"
   health_checks         = [google_compute_health_check.vault_iap.0.self_link]
 
+  security_policy = var.cloud_armor_enabled ? google_compute_security_policy.vault.0.id : ""
+
   backend {
     group = google_compute_region_instance_group_manager.vault.instance_group
   }

--- a/network_external_lb.tf
+++ b/network_external_lb.tf
@@ -25,6 +25,9 @@ resource "google_compute_backend_service" "vault" {
   port_name             = "vault-http"
   health_checks         = [google_compute_health_check.vault.self_link]
 
+  // This value cannot be set for TCP backend services
+  // security_policy = var.cloud_armor_enabled ? google_compute_security_policy.vault.0.id : ""
+
   backend {
     // This value used to be set, but backend services that share the same
     // target instance group must have the same value. The optional IAP

--- a/vars.tf
+++ b/vars.tf
@@ -132,3 +132,9 @@ variable "iap_member_emails" {
   type    = string
   default = "IAP member emails"
 }
+
+variable "cloud_armor_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable GCP Cloud Armor"
+}


### PR DESCRIPTION
This PR introduces an option to enable [Cloud Armor](https://cloud.google.com/armor) for the optional IAP-protected  public endpoint (#2). 

```console
$ make terraform/apply IAP_ENABLED=true IAP_MEMBER_EMAILS="$YOUR_EMAIL@gmail.com" CLOUD_ARMOR_ENABLED=true
```